### PR TITLE
feat(organization&contacts): 조직도 및 연락처 기능 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,5 +41,15 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- 전화 -->
+        <intent>
+            <action android:name="android.intent.action.DIAL"/>
+            <data android:scheme="tel"/>
+        </intent>
+        <!-- 문자 -->
+        <intent>
+            <action android:name="android.intent.action.SENDTO"/>
+            <data android:scheme="sms"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/features/contacts/contacts_controller.dart
+++ b/lib/features/contacts/contacts_controller.dart
@@ -1,0 +1,62 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:wise_app/features/contacts/contacts_model.dart';
+import 'package:wise_app/features/contacts/contacts_repository.dart';
+
+part 'contacts_controller.g.dart';
+
+/// 연락처 목록 컨트롤러
+@riverpod
+class ContactsController extends _$ContactsController {
+  @override
+  FutureOr<List<Contact>> build() async {
+    return await ref.read(contactsRepositoryProvider).getContacts();
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(contactsRepositoryProvider).getContacts(),
+    );
+  }
+}
+
+/// 조직 목록 컨트롤러
+@riverpod
+class OrganizationsController extends _$OrganizationsController {
+  @override
+  FutureOr<List<Organization>> build() async {
+    return await ref.read(contactsRepositoryProvider).getOrganizations();
+  }
+}
+
+@riverpod
+class FavoriteController extends _$FavoriteController {
+  @override
+  FutureOr<Set<String>> build() async {
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) return {};
+
+    final favorites = await ref
+        .read(contactsRepositoryProvider)
+        .getFavorites(userId);
+
+    return favorites.map((favorite) => favorite.contactId).toSet();
+  }
+
+  Future<void> toggleFavorite(String contactId) async {
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) return;
+
+    final currentFavorites = state.value ?? {};
+    if (currentFavorites.contains(contactId)) {
+      await ref
+          .read(contactsRepositoryProvider)
+          .removeFavorite(userId, contactId);
+    } else {
+      await ref.read(contactsRepositoryProvider).addFavorite(userId, contactId);
+    }
+
+    ref.invalidateSelf();
+  }
+}

--- a/lib/features/contacts/contacts_controller.g.dart
+++ b/lib/features/contacts/contacts_controller.g.dart
@@ -1,0 +1,162 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 연락처 목록 컨트롤러
+
+@ProviderFor(ContactsController)
+const contactsControllerProvider = ContactsControllerProvider._();
+
+/// 연락처 목록 컨트롤러
+final class ContactsControllerProvider
+    extends $AsyncNotifierProvider<ContactsController, List<Contact>> {
+  /// 연락처 목록 컨트롤러
+  const ContactsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'contactsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$contactsControllerHash();
+
+  @$internal
+  @override
+  ContactsController create() => ContactsController();
+}
+
+String _$contactsControllerHash() =>
+    r'6e4bc3e3134ef65e8382922fa6918c08802619a6';
+
+/// 연락처 목록 컨트롤러
+
+abstract class _$ContactsController extends $AsyncNotifier<List<Contact>> {
+  FutureOr<List<Contact>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<List<Contact>>, List<Contact>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<List<Contact>>, List<Contact>>,
+              AsyncValue<List<Contact>>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}
+
+/// 조직 목록 컨트롤러
+
+@ProviderFor(OrganizationsController)
+const organizationsControllerProvider = OrganizationsControllerProvider._();
+
+/// 조직 목록 컨트롤러
+final class OrganizationsControllerProvider
+    extends
+        $AsyncNotifierProvider<OrganizationsController, List<Organization>> {
+  /// 조직 목록 컨트롤러
+  const OrganizationsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'organizationsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$organizationsControllerHash();
+
+  @$internal
+  @override
+  OrganizationsController create() => OrganizationsController();
+}
+
+String _$organizationsControllerHash() =>
+    r'8fc2befe34b2362d1bfc0df7cea4ed266b41da2d';
+
+/// 조직 목록 컨트롤러
+
+abstract class _$OrganizationsController
+    extends $AsyncNotifier<List<Organization>> {
+  FutureOr<List<Organization>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref as $Ref<AsyncValue<List<Organization>>, List<Organization>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<List<Organization>>, List<Organization>>,
+              AsyncValue<List<Organization>>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}
+
+@ProviderFor(FavoriteController)
+const favoriteControllerProvider = FavoriteControllerProvider._();
+
+final class FavoriteControllerProvider
+    extends $AsyncNotifierProvider<FavoriteController, Set<String>> {
+  const FavoriteControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'favoriteControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$favoriteControllerHash();
+
+  @$internal
+  @override
+  FavoriteController create() => FavoriteController();
+}
+
+String _$favoriteControllerHash() =>
+    r'4797dfd591a8006a8f0dcec3e700f4f3e77e0f6b';
+
+abstract class _$FavoriteController extends $AsyncNotifier<Set<String>> {
+  FutureOr<Set<String>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<Set<String>>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<Set<String>>, Set<String>>,
+              AsyncValue<Set<String>>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/contacts/contacts_model.dart
+++ b/lib/features/contacts/contacts_model.dart
@@ -1,0 +1,53 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'contacts_model.freezed.dart';
+part 'contacts_model.g.dart';
+
+@freezed
+abstract class Organization with _$Organization {
+  const factory Organization({
+    required String id,
+    required String name,
+    @JsonKey(name: 'parent_id') String? parentId,
+    @Default(0) int level,
+    @JsonKey(name: 'sort_order') @Default(0) int sortOrder,
+    @JsonKey(name: 'is_active') @Default(true) bool isActive,
+  }) = _Organization;
+
+  factory Organization.fromJson(Map<String, dynamic> json) =>
+      _$OrganizationFromJson(json);
+}
+
+@freezed
+abstract class Contact with _$Contact {
+  const factory Contact({
+    required String id,
+    required String email,
+    String? username,
+    String? position,
+    String? department,
+    @JsonKey(name: 'organization_id') String? organizationId,
+    @JsonKey(name: 'mobile_phone') String? mobilePhone,
+    @JsonKey(name: 'office_phone') String? officePhone,
+    @JsonKey(name: 'avatar_url') String? avatarUrl,
+    @JsonKey(name: 'work_location') String? workLocation,
+    @JsonKey(name: 'work_role') String? workRole,
+    @Default('offline') String status,
+  }) = _Contact;
+
+  factory Contact.fromJson(Map<String, dynamic> json) =>
+      _$ContactFromJson(json);
+}
+
+@freezed
+abstract class Favorite with _$Favorite {
+  const factory Favorite({
+    required String id,
+    @JsonKey(name: 'user_id') required String userId,
+    @JsonKey(name: 'contact_id') required String contactId,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  }) = _Favorite;
+
+  factory Favorite.fromJson(Map<String, dynamic> json) =>
+      _$FavoriteFromJson(json);
+}

--- a/lib/features/contacts/contacts_model.freezed.dart
+++ b/lib/features/contacts/contacts_model.freezed.dart
@@ -1,0 +1,860 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'contacts_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Organization {
+
+ String get id; String get name;@JsonKey(name: 'parent_id') String? get parentId; int get level;@JsonKey(name: 'sort_order') int get sortOrder;@JsonKey(name: 'is_active') bool get isActive;
+/// Create a copy of Organization
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OrganizationCopyWith<Organization> get copyWith => _$OrganizationCopyWithImpl<Organization>(this as Organization, _$identity);
+
+  /// Serializes this Organization to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Organization&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.parentId, parentId) || other.parentId == parentId)&&(identical(other.level, level) || other.level == level)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isActive, isActive) || other.isActive == isActive));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,parentId,level,sortOrder,isActive);
+
+@override
+String toString() {
+  return 'Organization(id: $id, name: $name, parentId: $parentId, level: $level, sortOrder: $sortOrder, isActive: $isActive)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $OrganizationCopyWith<$Res>  {
+  factory $OrganizationCopyWith(Organization value, $Res Function(Organization) _then) = _$OrganizationCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name,@JsonKey(name: 'parent_id') String? parentId, int level,@JsonKey(name: 'sort_order') int sortOrder,@JsonKey(name: 'is_active') bool isActive
+});
+
+
+
+
+}
+/// @nodoc
+class _$OrganizationCopyWithImpl<$Res>
+    implements $OrganizationCopyWith<$Res> {
+  _$OrganizationCopyWithImpl(this._self, this._then);
+
+  final Organization _self;
+  final $Res Function(Organization) _then;
+
+/// Create a copy of Organization
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? parentId = freezed,Object? level = null,Object? sortOrder = null,Object? isActive = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,parentId: freezed == parentId ? _self.parentId : parentId // ignore: cast_nullable_to_non_nullable
+as String?,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
+as int,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Organization].
+extension OrganizationPatterns on Organization {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Organization value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Organization() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Organization value)  $default,){
+final _that = this;
+switch (_that) {
+case _Organization():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Organization value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Organization() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'parent_id')  String? parentId,  int level, @JsonKey(name: 'sort_order')  int sortOrder, @JsonKey(name: 'is_active')  bool isActive)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Organization() when $default != null:
+return $default(_that.id,_that.name,_that.parentId,_that.level,_that.sortOrder,_that.isActive);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'parent_id')  String? parentId,  int level, @JsonKey(name: 'sort_order')  int sortOrder, @JsonKey(name: 'is_active')  bool isActive)  $default,) {final _that = this;
+switch (_that) {
+case _Organization():
+return $default(_that.id,_that.name,_that.parentId,_that.level,_that.sortOrder,_that.isActive);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @JsonKey(name: 'parent_id')  String? parentId,  int level, @JsonKey(name: 'sort_order')  int sortOrder, @JsonKey(name: 'is_active')  bool isActive)?  $default,) {final _that = this;
+switch (_that) {
+case _Organization() when $default != null:
+return $default(_that.id,_that.name,_that.parentId,_that.level,_that.sortOrder,_that.isActive);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Organization implements Organization {
+  const _Organization({required this.id, required this.name, @JsonKey(name: 'parent_id') this.parentId, this.level = 0, @JsonKey(name: 'sort_order') this.sortOrder = 0, @JsonKey(name: 'is_active') this.isActive = true});
+  factory _Organization.fromJson(Map<String, dynamic> json) => _$OrganizationFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override@JsonKey(name: 'parent_id') final  String? parentId;
+@override@JsonKey() final  int level;
+@override@JsonKey(name: 'sort_order') final  int sortOrder;
+@override@JsonKey(name: 'is_active') final  bool isActive;
+
+/// Create a copy of Organization
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OrganizationCopyWith<_Organization> get copyWith => __$OrganizationCopyWithImpl<_Organization>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$OrganizationToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Organization&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.parentId, parentId) || other.parentId == parentId)&&(identical(other.level, level) || other.level == level)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isActive, isActive) || other.isActive == isActive));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,parentId,level,sortOrder,isActive);
+
+@override
+String toString() {
+  return 'Organization(id: $id, name: $name, parentId: $parentId, level: $level, sortOrder: $sortOrder, isActive: $isActive)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OrganizationCopyWith<$Res> implements $OrganizationCopyWith<$Res> {
+  factory _$OrganizationCopyWith(_Organization value, $Res Function(_Organization) _then) = __$OrganizationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name,@JsonKey(name: 'parent_id') String? parentId, int level,@JsonKey(name: 'sort_order') int sortOrder,@JsonKey(name: 'is_active') bool isActive
+});
+
+
+
+
+}
+/// @nodoc
+class __$OrganizationCopyWithImpl<$Res>
+    implements _$OrganizationCopyWith<$Res> {
+  __$OrganizationCopyWithImpl(this._self, this._then);
+
+  final _Organization _self;
+  final $Res Function(_Organization) _then;
+
+/// Create a copy of Organization
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? parentId = freezed,Object? level = null,Object? sortOrder = null,Object? isActive = null,}) {
+  return _then(_Organization(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,parentId: freezed == parentId ? _self.parentId : parentId // ignore: cast_nullable_to_non_nullable
+as String?,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
+as int,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$Contact {
+
+ String get id; String get email; String? get username; String? get position; String? get department;@JsonKey(name: 'organization_id') String? get organizationId;@JsonKey(name: 'mobile_phone') String? get mobilePhone;@JsonKey(name: 'office_phone') String? get officePhone;@JsonKey(name: 'avatar_url') String? get avatarUrl;@JsonKey(name: 'work_location') String? get workLocation;@JsonKey(name: 'work_role') String? get workRole; String get status;
+/// Create a copy of Contact
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ContactCopyWith<Contact> get copyWith => _$ContactCopyWithImpl<Contact>(this as Contact, _$identity);
+
+  /// Serializes this Contact to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Contact&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.username, username) || other.username == username)&&(identical(other.position, position) || other.position == position)&&(identical(other.department, department) || other.department == department)&&(identical(other.organizationId, organizationId) || other.organizationId == organizationId)&&(identical(other.mobilePhone, mobilePhone) || other.mobilePhone == mobilePhone)&&(identical(other.officePhone, officePhone) || other.officePhone == officePhone)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.workLocation, workLocation) || other.workLocation == workLocation)&&(identical(other.workRole, workRole) || other.workRole == workRole)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,username,position,department,organizationId,mobilePhone,officePhone,avatarUrl,workLocation,workRole,status);
+
+@override
+String toString() {
+  return 'Contact(id: $id, email: $email, username: $username, position: $position, department: $department, organizationId: $organizationId, mobilePhone: $mobilePhone, officePhone: $officePhone, avatarUrl: $avatarUrl, workLocation: $workLocation, workRole: $workRole, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ContactCopyWith<$Res>  {
+  factory $ContactCopyWith(Contact value, $Res Function(Contact) _then) = _$ContactCopyWithImpl;
+@useResult
+$Res call({
+ String id, String email, String? username, String? position, String? department,@JsonKey(name: 'organization_id') String? organizationId,@JsonKey(name: 'mobile_phone') String? mobilePhone,@JsonKey(name: 'office_phone') String? officePhone,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'work_location') String? workLocation,@JsonKey(name: 'work_role') String? workRole, String status
+});
+
+
+
+
+}
+/// @nodoc
+class _$ContactCopyWithImpl<$Res>
+    implements $ContactCopyWith<$Res> {
+  _$ContactCopyWithImpl(this._self, this._then);
+
+  final Contact _self;
+  final $Res Function(Contact) _then;
+
+/// Create a copy of Contact
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? email = null,Object? username = freezed,Object? position = freezed,Object? department = freezed,Object? organizationId = freezed,Object? mobilePhone = freezed,Object? officePhone = freezed,Object? avatarUrl = freezed,Object? workLocation = freezed,Object? workRole = freezed,Object? status = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as String?,department: freezed == department ? _self.department : department // ignore: cast_nullable_to_non_nullable
+as String?,organizationId: freezed == organizationId ? _self.organizationId : organizationId // ignore: cast_nullable_to_non_nullable
+as String?,mobilePhone: freezed == mobilePhone ? _self.mobilePhone : mobilePhone // ignore: cast_nullable_to_non_nullable
+as String?,officePhone: freezed == officePhone ? _self.officePhone : officePhone // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,workLocation: freezed == workLocation ? _self.workLocation : workLocation // ignore: cast_nullable_to_non_nullable
+as String?,workRole: freezed == workRole ? _self.workRole : workRole // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Contact].
+extension ContactPatterns on Contact {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Contact value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Contact() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Contact value)  $default,){
+final _that = this;
+switch (_that) {
+case _Contact():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Contact value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Contact() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String email,  String? username,  String? position,  String? department, @JsonKey(name: 'organization_id')  String? organizationId, @JsonKey(name: 'mobile_phone')  String? mobilePhone, @JsonKey(name: 'office_phone')  String? officePhone, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'work_location')  String? workLocation, @JsonKey(name: 'work_role')  String? workRole,  String status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Contact() when $default != null:
+return $default(_that.id,_that.email,_that.username,_that.position,_that.department,_that.organizationId,_that.mobilePhone,_that.officePhone,_that.avatarUrl,_that.workLocation,_that.workRole,_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String email,  String? username,  String? position,  String? department, @JsonKey(name: 'organization_id')  String? organizationId, @JsonKey(name: 'mobile_phone')  String? mobilePhone, @JsonKey(name: 'office_phone')  String? officePhone, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'work_location')  String? workLocation, @JsonKey(name: 'work_role')  String? workRole,  String status)  $default,) {final _that = this;
+switch (_that) {
+case _Contact():
+return $default(_that.id,_that.email,_that.username,_that.position,_that.department,_that.organizationId,_that.mobilePhone,_that.officePhone,_that.avatarUrl,_that.workLocation,_that.workRole,_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String email,  String? username,  String? position,  String? department, @JsonKey(name: 'organization_id')  String? organizationId, @JsonKey(name: 'mobile_phone')  String? mobilePhone, @JsonKey(name: 'office_phone')  String? officePhone, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'work_location')  String? workLocation, @JsonKey(name: 'work_role')  String? workRole,  String status)?  $default,) {final _that = this;
+switch (_that) {
+case _Contact() when $default != null:
+return $default(_that.id,_that.email,_that.username,_that.position,_that.department,_that.organizationId,_that.mobilePhone,_that.officePhone,_that.avatarUrl,_that.workLocation,_that.workRole,_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Contact implements Contact {
+  const _Contact({required this.id, required this.email, this.username, this.position, this.department, @JsonKey(name: 'organization_id') this.organizationId, @JsonKey(name: 'mobile_phone') this.mobilePhone, @JsonKey(name: 'office_phone') this.officePhone, @JsonKey(name: 'avatar_url') this.avatarUrl, @JsonKey(name: 'work_location') this.workLocation, @JsonKey(name: 'work_role') this.workRole, this.status = 'offline'});
+  factory _Contact.fromJson(Map<String, dynamic> json) => _$ContactFromJson(json);
+
+@override final  String id;
+@override final  String email;
+@override final  String? username;
+@override final  String? position;
+@override final  String? department;
+@override@JsonKey(name: 'organization_id') final  String? organizationId;
+@override@JsonKey(name: 'mobile_phone') final  String? mobilePhone;
+@override@JsonKey(name: 'office_phone') final  String? officePhone;
+@override@JsonKey(name: 'avatar_url') final  String? avatarUrl;
+@override@JsonKey(name: 'work_location') final  String? workLocation;
+@override@JsonKey(name: 'work_role') final  String? workRole;
+@override@JsonKey() final  String status;
+
+/// Create a copy of Contact
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ContactCopyWith<_Contact> get copyWith => __$ContactCopyWithImpl<_Contact>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ContactToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Contact&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.username, username) || other.username == username)&&(identical(other.position, position) || other.position == position)&&(identical(other.department, department) || other.department == department)&&(identical(other.organizationId, organizationId) || other.organizationId == organizationId)&&(identical(other.mobilePhone, mobilePhone) || other.mobilePhone == mobilePhone)&&(identical(other.officePhone, officePhone) || other.officePhone == officePhone)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.workLocation, workLocation) || other.workLocation == workLocation)&&(identical(other.workRole, workRole) || other.workRole == workRole)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,username,position,department,organizationId,mobilePhone,officePhone,avatarUrl,workLocation,workRole,status);
+
+@override
+String toString() {
+  return 'Contact(id: $id, email: $email, username: $username, position: $position, department: $department, organizationId: $organizationId, mobilePhone: $mobilePhone, officePhone: $officePhone, avatarUrl: $avatarUrl, workLocation: $workLocation, workRole: $workRole, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ContactCopyWith<$Res> implements $ContactCopyWith<$Res> {
+  factory _$ContactCopyWith(_Contact value, $Res Function(_Contact) _then) = __$ContactCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String email, String? username, String? position, String? department,@JsonKey(name: 'organization_id') String? organizationId,@JsonKey(name: 'mobile_phone') String? mobilePhone,@JsonKey(name: 'office_phone') String? officePhone,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'work_location') String? workLocation,@JsonKey(name: 'work_role') String? workRole, String status
+});
+
+
+
+
+}
+/// @nodoc
+class __$ContactCopyWithImpl<$Res>
+    implements _$ContactCopyWith<$Res> {
+  __$ContactCopyWithImpl(this._self, this._then);
+
+  final _Contact _self;
+  final $Res Function(_Contact) _then;
+
+/// Create a copy of Contact
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? email = null,Object? username = freezed,Object? position = freezed,Object? department = freezed,Object? organizationId = freezed,Object? mobilePhone = freezed,Object? officePhone = freezed,Object? avatarUrl = freezed,Object? workLocation = freezed,Object? workRole = freezed,Object? status = null,}) {
+  return _then(_Contact(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as String?,department: freezed == department ? _self.department : department // ignore: cast_nullable_to_non_nullable
+as String?,organizationId: freezed == organizationId ? _self.organizationId : organizationId // ignore: cast_nullable_to_non_nullable
+as String?,mobilePhone: freezed == mobilePhone ? _self.mobilePhone : mobilePhone // ignore: cast_nullable_to_non_nullable
+as String?,officePhone: freezed == officePhone ? _self.officePhone : officePhone // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,workLocation: freezed == workLocation ? _self.workLocation : workLocation // ignore: cast_nullable_to_non_nullable
+as String?,workRole: freezed == workRole ? _self.workRole : workRole // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$Favorite {
+
+ String get id;@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'contact_id') String get contactId;@JsonKey(name: 'created_at') DateTime? get createdAt;
+/// Create a copy of Favorite
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FavoriteCopyWith<Favorite> get copyWith => _$FavoriteCopyWithImpl<Favorite>(this as Favorite, _$identity);
+
+  /// Serializes this Favorite to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Favorite&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.contactId, contactId) || other.contactId == contactId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,contactId,createdAt);
+
+@override
+String toString() {
+  return 'Favorite(id: $id, userId: $userId, contactId: $contactId, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FavoriteCopyWith<$Res>  {
+  factory $FavoriteCopyWith(Favorite value, $Res Function(Favorite) _then) = _$FavoriteCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'contact_id') String contactId,@JsonKey(name: 'created_at') DateTime? createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$FavoriteCopyWithImpl<$Res>
+    implements $FavoriteCopyWith<$Res> {
+  _$FavoriteCopyWithImpl(this._self, this._then);
+
+  final Favorite _self;
+  final $Res Function(Favorite) _then;
+
+/// Create a copy of Favorite
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? contactId = null,Object? createdAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,contactId: null == contactId ? _self.contactId : contactId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Favorite].
+extension FavoritePatterns on Favorite {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Favorite value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Favorite() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Favorite value)  $default,){
+final _that = this;
+switch (_that) {
+case _Favorite():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Favorite value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Favorite() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'contact_id')  String contactId, @JsonKey(name: 'created_at')  DateTime? createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Favorite() when $default != null:
+return $default(_that.id,_that.userId,_that.contactId,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'contact_id')  String contactId, @JsonKey(name: 'created_at')  DateTime? createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _Favorite():
+return $default(_that.id,_that.userId,_that.contactId,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'contact_id')  String contactId, @JsonKey(name: 'created_at')  DateTime? createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _Favorite() when $default != null:
+return $default(_that.id,_that.userId,_that.contactId,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Favorite implements Favorite {
+  const _Favorite({required this.id, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'contact_id') required this.contactId, @JsonKey(name: 'created_at') this.createdAt});
+  factory _Favorite.fromJson(Map<String, dynamic> json) => _$FavoriteFromJson(json);
+
+@override final  String id;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'contact_id') final  String contactId;
+@override@JsonKey(name: 'created_at') final  DateTime? createdAt;
+
+/// Create a copy of Favorite
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FavoriteCopyWith<_Favorite> get copyWith => __$FavoriteCopyWithImpl<_Favorite>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FavoriteToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Favorite&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.contactId, contactId) || other.contactId == contactId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,contactId,createdAt);
+
+@override
+String toString() {
+  return 'Favorite(id: $id, userId: $userId, contactId: $contactId, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FavoriteCopyWith<$Res> implements $FavoriteCopyWith<$Res> {
+  factory _$FavoriteCopyWith(_Favorite value, $Res Function(_Favorite) _then) = __$FavoriteCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'contact_id') String contactId,@JsonKey(name: 'created_at') DateTime? createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$FavoriteCopyWithImpl<$Res>
+    implements _$FavoriteCopyWith<$Res> {
+  __$FavoriteCopyWithImpl(this._self, this._then);
+
+  final _Favorite _self;
+  final $Res Function(_Favorite) _then;
+
+/// Create a copy of Favorite
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? contactId = null,Object? createdAt = freezed,}) {
+  return _then(_Favorite(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,contactId: null == contactId ? _self.contactId : contactId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/contacts/contacts_model.g.dart
+++ b/lib/features/contacts/contacts_model.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Organization _$OrganizationFromJson(Map<String, dynamic> json) =>
+    _Organization(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      parentId: json['parent_id'] as String?,
+      level: (json['level'] as num?)?.toInt() ?? 0,
+      sortOrder: (json['sort_order'] as num?)?.toInt() ?? 0,
+      isActive: json['is_active'] as bool? ?? true,
+    );
+
+Map<String, dynamic> _$OrganizationToJson(_Organization instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'parent_id': instance.parentId,
+      'level': instance.level,
+      'sort_order': instance.sortOrder,
+      'is_active': instance.isActive,
+    };
+
+_Contact _$ContactFromJson(Map<String, dynamic> json) => _Contact(
+  id: json['id'] as String,
+  email: json['email'] as String,
+  username: json['username'] as String?,
+  position: json['position'] as String?,
+  department: json['department'] as String?,
+  organizationId: json['organization_id'] as String?,
+  mobilePhone: json['mobile_phone'] as String?,
+  officePhone: json['office_phone'] as String?,
+  avatarUrl: json['avatar_url'] as String?,
+  workLocation: json['work_location'] as String?,
+  workRole: json['work_role'] as String?,
+  status: json['status'] as String? ?? 'offline',
+);
+
+Map<String, dynamic> _$ContactToJson(_Contact instance) => <String, dynamic>{
+  'id': instance.id,
+  'email': instance.email,
+  'username': instance.username,
+  'position': instance.position,
+  'department': instance.department,
+  'organization_id': instance.organizationId,
+  'mobile_phone': instance.mobilePhone,
+  'office_phone': instance.officePhone,
+  'avatar_url': instance.avatarUrl,
+  'work_location': instance.workLocation,
+  'work_role': instance.workRole,
+  'status': instance.status,
+};
+
+_Favorite _$FavoriteFromJson(Map<String, dynamic> json) => _Favorite(
+  id: json['id'] as String,
+  userId: json['user_id'] as String,
+  contactId: json['contact_id'] as String,
+  createdAt: json['created_at'] == null
+      ? null
+      : DateTime.parse(json['created_at'] as String),
+);
+
+Map<String, dynamic> _$FavoriteToJson(_Favorite instance) => <String, dynamic>{
+  'id': instance.id,
+  'user_id': instance.userId,
+  'contact_id': instance.contactId,
+  'created_at': instance.createdAt?.toIso8601String(),
+};

--- a/lib/features/contacts/contacts_repository.dart
+++ b/lib/features/contacts/contacts_repository.dart
@@ -1,0 +1,69 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:wise_app/features/contacts/contacts_model.dart';
+
+part 'contacts_repository.g.dart';
+
+@riverpod
+ContactsRepository contactsRepository(Ref ref) =>
+    ContactsRepository(Supabase.instance.client);
+
+class ContactsRepository {
+  final SupabaseClient _client;
+
+  ContactsRepository(this._client);
+
+  Future<List<Organization>> getOrganizations() async {
+    final response = await _client
+        .from('organizations')
+        .select()
+        .eq('is_active', true)
+        .order('level')
+        .order('sort_order');
+
+    return (response as List)
+        .map((json) => Organization.fromJson(json))
+        .toList();
+  }
+
+  Future<List<Contact>> getContacts() async {
+    final response = await _client.from('profiles').select();
+
+    return (response as List).map((json) => Contact.fromJson(json)).toList();
+  }
+
+  Future<List<Contact>> getContactsByOrganizationId(
+    String organizationId,
+  ) async {
+    final response = await _client
+        .from('profiles')
+        .select()
+        .eq('organization_id', organizationId);
+
+    return (response as List).map((json) => Contact.fromJson(json)).toList();
+  }
+
+  Future<Set<Favorite>> getFavorites(String userId) async {
+    final response = await _client
+        .from('favorites')
+        .select()
+        .eq('user_id', userId);
+
+    return (response as List).map((json) => Favorite.fromJson(json)).toSet();
+  }
+
+  Future<void> addFavorite(String userId, String contactId) async {
+    await _client.from('favorites').insert({
+      'user_id': userId,
+      'contact_id': contactId,
+    });
+  }
+
+  Future<void> removeFavorite(String userId, String contactId) async {
+    await _client
+        .from('favorites')
+        .delete()
+        .eq('user_id', userId)
+        .eq('contact_id', contactId);
+  }
+}

--- a/lib/features/contacts/contacts_repository.g.dart
+++ b/lib/features/contacts/contacts_repository.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(contactsRepository)
+const contactsRepositoryProvider = ContactsRepositoryProvider._();
+
+final class ContactsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          ContactsRepository,
+          ContactsRepository,
+          ContactsRepository
+        >
+    with $Provider<ContactsRepository> {
+  const ContactsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'contactsRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$contactsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<ContactsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ContactsRepository create(Ref ref) {
+    return contactsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ContactsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ContactsRepository>(value),
+    );
+  }
+}
+
+String _$contactsRepositoryHash() =>
+    r'48b0e6504bb2e6d7cdb69af2edab1bb0f95b5f83';

--- a/lib/features/contacts/contacts_screen.dart
+++ b/lib/features/contacts/contacts_screen.dart
@@ -1,0 +1,1149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:wise_app/features/contacts/contacts_controller.dart';
+import 'package:wise_app/features/contacts/contacts_model.dart';
+
+class ContactsScreen extends ConsumerStatefulWidget {
+  const ContactsScreen({super.key});
+
+  @override
+  ConsumerState<ContactsScreen> createState() => _ContactsScreenState();
+}
+
+class _ContactsScreenState extends ConsumerState<ContactsScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  bool _isSearching = false;
+  String? _selectedOrganization;
+  List<String> _recentSearches = ['김철수', '백엔드팀', '마케팅'];
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  String _getSelectedOrgName(List<Organization> organizations) {
+    if (_selectedOrganization == null) return '전체';
+    final org = organizations.firstWhere(
+      (o) => o.id == _selectedOrganization,
+      orElse: () => Organization(id: '', name: '전체'),
+    );
+    return org.name;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  // 초성 검색 지원
+  bool _matchesSearch(Contact contact, String query) {
+    if (query.isEmpty) return true;
+
+    final lowerQuery = query.toLowerCase();
+    final name = contact.username ?? '';
+    final dept = contact.department ?? '';
+    final position = contact.position ?? '';
+
+    // 일반 검색
+    if (name.toLowerCase().contains(lowerQuery) ||
+        dept.toLowerCase().contains(lowerQuery) ||
+        position.toLowerCase().contains(lowerQuery)) {
+      return true;
+    }
+
+    // 초성 검색
+    if (_isKoreanInitials(query)) {
+      final nameInitials = _getKoreanInitials(name);
+      return nameInitials.contains(query);
+    }
+
+    return false;
+  }
+
+  bool _isKoreanInitials(String text) {
+    const initials = 'ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ';
+    return text.split('').every((char) => initials.contains(char));
+  }
+
+  String _getKoreanInitials(String text) {
+    const initials = [
+      'ㄱ',
+      'ㄲ',
+      'ㄴ',
+      'ㄷ',
+      'ㄸ',
+      'ㄹ',
+      'ㅁ',
+      'ㅂ',
+      'ㅃ',
+      'ㅅ',
+      'ㅆ',
+      'ㅇ',
+      'ㅈ',
+      'ㅉ',
+      'ㅊ',
+      'ㅋ',
+      'ㅌ',
+      'ㅍ',
+      'ㅎ',
+    ];
+    final buffer = StringBuffer();
+
+    for (final char in text.runes) {
+      if (char >= 0xAC00 && char <= 0xD7A3) {
+        final index = ((char - 0xAC00) / 588).floor();
+        buffer.write(initials[index]);
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  void _toggleSearch() {
+    setState(() {
+      _isSearching = !_isSearching;
+      if (!_isSearching) {
+        _searchController.clear();
+        _searchQuery = '';
+      }
+    });
+  }
+
+  void _addToRecentSearches(String query) {
+    if (query.isNotEmpty && !_recentSearches.contains(query)) {
+      setState(() {
+        _recentSearches.insert(0, query);
+        if (_recentSearches.length > 5) {
+          _recentSearches = _recentSearches.sublist(0, 5);
+        }
+      });
+    }
+  }
+
+  void _showOrganizationPicker(
+    List<Organization> organizations,
+    List<Contact> contacts,
+  ) {
+    // 조직별 인원수 계산 (하위 조직 포함)
+    int getContactCount(String? orgId) {
+      if (orgId == null) return contacts.length;
+
+      // 해당 조직 + 하위 조직의 모든 인원수
+      final childOrgIds = _getDescendantOrgIds(orgId, organizations);
+      return contacts
+          .where(
+            (c) =>
+                c.organizationId == orgId ||
+                childOrgIds.contains(c.organizationId),
+          )
+          .length;
+    }
+
+    // 최상위 조직만 필터 (level == 1: 본부)
+    final topLevelOrgs = organizations.where((o) => o.level == 1).toList();
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => StatefulBuilder(
+        builder: (context, setModalState) => DraggableScrollableSheet(
+          initialChildSize: 0.6,
+          minChildSize: 0.3,
+          maxChildSize: 0.9,
+          expand: false,
+          builder: (context, scrollController) => Column(
+            children: [
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 12),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade300,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Row(
+                  children: [
+                    Text(
+                      '조직 선택',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const Spacer(),
+                    TextButton(
+                      onPressed: () {
+                        setState(() => _selectedOrganization = null);
+                        Navigator.pop(context);
+                      },
+                      child: const Text('전체 보기'),
+                    ),
+                  ],
+                ),
+              ),
+              const Divider(),
+              Expanded(
+                child: ListView(
+                  controller: scrollController,
+                  children: [
+                    // 전체 항목
+                    _buildOrgTile(
+                      context: context,
+                      orgId: null,
+                      name: '전체',
+                      count: contacts.length,
+                      icon: Icons.groups,
+                      isSelected: _selectedOrganization == null,
+                      onTap: () {
+                        setState(() => _selectedOrganization = null);
+                        Navigator.pop(context);
+                      },
+                    ),
+                    const Divider(height: 1),
+                    // 본부별 ExpansionTile
+                    ...topLevelOrgs.map((division) {
+                      final childOrgs = organizations
+                          .where((o) => o.parentId == division.id)
+                          .toList();
+                      final isSelected = division.id == _selectedOrganization;
+                      final hasSelectedChild = childOrgs.any(
+                        (c) => c.id == _selectedOrganization,
+                      );
+
+                      if (childOrgs.isEmpty) {
+                        // 하위 조직이 없으면 일반 ListTile
+                        return _buildOrgTile(
+                          context: context,
+                          orgId: division.id,
+                          name: division.name,
+                          count: getContactCount(division.id),
+                          icon: Icons.corporate_fare,
+                          isSelected: isSelected,
+                          onTap: () {
+                            setState(() => _selectedOrganization = division.id);
+                            Navigator.pop(context);
+                          },
+                        );
+                      }
+
+                      // 하위 조직이 있으면 ExpansionTile
+                      return _ExpandableOrgTile(
+                        division: division,
+                        childOrgs: childOrgs,
+                        isSelected: isSelected,
+                        initiallyExpanded: hasSelectedChild || isSelected,
+                        contactCount: getContactCount(division.id),
+                        selectedOrganization: _selectedOrganization,
+                        onSelectDivision: () {
+                          setState(() => _selectedOrganization = division.id);
+                          Navigator.pop(context);
+                        },
+                        onSelectTeam: (teamId) {
+                          setState(() => _selectedOrganization = teamId);
+                          Navigator.pop(context);
+                        },
+                        getContactCount: getContactCount,
+                      );
+                    }),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 하위 조직 ID 목록 가져오기
+  Set<String> _getDescendantOrgIds(String parentId, List<Organization> orgs) {
+    final descendants = <String>{};
+    final directChildren = orgs.where((o) => o.parentId == parentId);
+    for (final child in directChildren) {
+      descendants.add(child.id);
+      descendants.addAll(_getDescendantOrgIds(child.id, orgs));
+    }
+    return descendants;
+  }
+
+  // 조직 타일 빌더
+  Widget _buildOrgTile({
+    required BuildContext context,
+    required String? orgId,
+    required String name,
+    required int count,
+    required IconData icon,
+    required bool isSelected,
+    required VoidCallback onTap,
+    double indent = 0,
+  }) {
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: isSelected
+            ? Theme.of(context).colorScheme.primary
+            : Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: Icon(icon, color: isSelected ? Colors.white : null, size: 20),
+      ),
+      title: Text(
+        '$name ($count)',
+        style: TextStyle(
+          fontWeight: indent > 0 ? FontWeight.normal : FontWeight.bold,
+          color: isSelected ? Theme.of(context).colorScheme.primary : null,
+        ),
+      ),
+      trailing: isSelected
+          ? Icon(
+              Icons.check_circle,
+              color: Theme.of(context).colorScheme.primary,
+            )
+          : null,
+      contentPadding: EdgeInsets.only(left: 16 + indent, right: 16),
+      onTap: onTap,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final contactsAsync = ref.watch(contactsControllerProvider);
+    final organizationsAsync = ref.watch(organizationsControllerProvider);
+    final favoritesAsync = ref.watch(favoriteControllerProvider);
+
+    final contacts = contactsAsync.value ?? [];
+    final organizations = organizationsAsync.value ?? [];
+    final selectedOrgName = _getSelectedOrgName(organizations);
+    final favoriteIds = favoritesAsync.value ?? {};
+
+    return Scaffold(
+      appBar: AppBar(
+        titleSpacing: 0,
+        title: _isSearching
+            ? TextField(
+                controller: _searchController,
+                autofocus: true,
+                decoration: InputDecoration(
+                  hintText: '이름, 부서, 초성(ㄱㅊㅅ)으로 검색...',
+                  border: InputBorder.none,
+                  hintStyle: TextStyle(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.5),
+                    fontSize: 14,
+                  ),
+                ),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+                onChanged: (value) => setState(() => _searchQuery = value),
+                onSubmitted: _addToRecentSearches,
+              )
+            : InkWell(
+                onTap: () => _showOrganizationPicker(organizations, contacts),
+                borderRadius: BorderRadius.circular(8),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        selectedOrgName,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const Icon(Icons.arrow_drop_down, size: 24),
+                    ],
+                  ),
+                ),
+              ),
+        leading: _isSearching
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: _toggleSearch,
+              )
+            : null,
+        actions: [
+          if (!_isSearching)
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: _toggleSearch,
+            ),
+          if (_isSearching && _searchQuery.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _searchController.clear();
+                setState(() => _searchQuery = '');
+              },
+            ),
+        ],
+      ),
+      body: contactsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(child: Text('오류: $error')),
+        data: (contacts) {
+          // 선택된 조직 + 하위 조직 ID 목록
+          final selectedOrgIds = _selectedOrganization != null
+              ? {
+                  _selectedOrganization!,
+                  ..._getDescendantOrgIds(
+                    _selectedOrganization!,
+                    organizations,
+                  ),
+                }
+              : <String>{};
+
+          // 필터링
+          var filteredContacts = contacts.where((c) {
+            // 조직 필터
+            if (_selectedOrganization != null &&
+                !selectedOrgIds.contains(c.organizationId)) {
+              return false;
+            }
+            return _matchesSearch(c, _searchQuery);
+          }).toList();
+
+          // 즐겨찾기 상단 정렬
+          filteredContacts.sort((a, b) {
+            final aFav = favoriteIds.contains(a.id);
+            final bFav = favoriteIds.contains(b.id);
+            if (aFav && !bFav) return -1;
+            if (!aFav && bFav) return 1;
+            return (a.username ?? '').compareTo(b.username ?? '');
+          });
+
+          return Column(
+            children: [
+              // 최근 검색 (검색 모드일 때만)
+              if (_isSearching &&
+                  _searchQuery.isEmpty &&
+                  _recentSearches.isNotEmpty)
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            '최근 검색',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.grey.shade600,
+                            ),
+                          ),
+                          const Spacer(),
+                          TextButton(
+                            onPressed: () =>
+                                setState(() => _recentSearches.clear()),
+                            child: const Text('전체 삭제'),
+                          ),
+                        ],
+                      ),
+                      Wrap(
+                        spacing: 8,
+                        children: _recentSearches
+                            .map(
+                              (search) => ActionChip(
+                                label: Text(search),
+                                onPressed: () {
+                                  _searchController.text = search;
+                                  setState(() => _searchQuery = search);
+                                },
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ],
+                  ),
+                ),
+              // 연락처 리스트
+              Expanded(
+                child: filteredContacts.isEmpty
+                    ? Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.search_off,
+                              size: 64,
+                              color: Colors.grey.shade400,
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              '검색 결과가 없습니다',
+                              style: TextStyle(color: Colors.grey.shade600),
+                            ),
+                          ],
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.all(16),
+                        itemCount: filteredContacts.length,
+                        itemBuilder: (context, index) {
+                          final contact = filteredContacts[index];
+                          final isFavorite = favoriteIds.contains(contact.id);
+                          return _ContactCard(
+                            contact: contact,
+                            isFavorite: isFavorite,
+                            onFavoriteToggle: () {
+                              ref
+                                  .read(favoriteControllerProvider.notifier)
+                                  .toggleFavorite(contact.id);
+                            },
+                            onTap: () => _showContactDetail(
+                              context,
+                              contact,
+                              isFavorite,
+                            ),
+                          );
+                        },
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  void _showContactDetail(
+    BuildContext context,
+    Contact contact,
+    bool isFavorite,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => ContactDetailSheet(
+        contact: contact,
+        isFavorite: isFavorite,
+        onOrganizationTap: () {
+          Navigator.pop(context);
+          setState(() => _selectedOrganization = contact.organizationId);
+        },
+        onFavoriteToggle: () {
+          ref
+              .read(favoriteControllerProvider.notifier)
+              .toggleFavorite(contact.id);
+          Navigator.pop(context);
+        },
+      ),
+    );
+  }
+}
+
+// 상태 색상
+Color _getStatusColor(String status) {
+  switch (status) {
+    case 'online':
+      return Colors.green;
+    case 'busy':
+      return Colors.red;
+    case 'away':
+      return Colors.orange;
+    default:
+      return Colors.grey;
+  }
+}
+
+String _getStatusText(String status) {
+  switch (status) {
+    case 'online':
+      return '온라인';
+    case 'busy':
+      return '바쁨';
+    case 'away':
+      return '자리비움';
+    default:
+      return '오프라인';
+  }
+}
+
+// 개선된 연락처 카드
+class _ContactCard extends StatelessWidget {
+  const _ContactCard({
+    required this.contact,
+    required this.isFavorite,
+    required this.onFavoriteToggle,
+    required this.onTap,
+  });
+
+  final Contact contact;
+  final bool isFavorite;
+  final VoidCallback onFavoriteToggle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 1,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              // 아바타 + 상태 표시
+              Stack(
+                children: [
+                  CircleAvatar(
+                    radius: 28,
+                    backgroundColor: Theme.of(
+                      context,
+                    ).colorScheme.primaryContainer,
+                    backgroundImage: contact.avatarUrl != null
+                        ? NetworkImage(contact.avatarUrl!)
+                        : null,
+                    child: contact.avatarUrl == null
+                        ? Text(
+                            (contact.username ?? 'U').substring(0, 1),
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onPrimaryContainer,
+                            ),
+                          )
+                        : null,
+                  ),
+                  // 상태 뱃지
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: Container(
+                      width: 14,
+                      height: 14,
+                      decoration: BoxDecoration(
+                        color: _getStatusColor(contact.status),
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.white, width: 2),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 12),
+              // 정보
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          contact.username ?? '이름 없음',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        // 즐겨찾기 버튼
+                        GestureDetector(
+                          onTap: onFavoriteToggle,
+                          child: Icon(
+                            isFavorite ? Icons.star : Icons.star_border,
+                            color: isFavorite ? Colors.amber : Colors.grey,
+                            size: 20,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '${contact.department ?? ''} · ${contact.position ?? ''}',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: Colors.grey.shade600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.phone_android,
+                          size: 12,
+                          color: Colors.grey.shade500,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          contact.mobilePhone ?? '',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey.shade500,
+                          ),
+                        ),
+                        if (contact.officePhone != null) ...[
+                          const SizedBox(width: 8),
+                          Icon(
+                            Icons.phone,
+                            size: 12,
+                            color: Colors.grey.shade500,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '내선 ${contact.officePhone}',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey.shade500,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              // 액션 버튼들
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: Icon(
+                      Icons.phone,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    onPressed: () async {
+                      final phone = contact.mobilePhone;
+                      if (phone != null && phone.isNotEmpty) {
+                        final uri = Uri.parse('tel:$phone');
+                        if (await canLaunchUrl(uri)) {
+                          await launchUrl(uri);
+                        }
+                      }
+                    },
+                    tooltip: '전화',
+                  ),
+                  IconButton(
+                    icon: Icon(
+                      Icons.email,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                    onPressed: () async {
+                      final phone = contact.mobilePhone;
+                      if (phone != null && phone.isNotEmpty) {
+                        final uri = Uri.parse('sms:$phone');
+                        if (await canLaunchUrl(uri)) {
+                          await launchUrl(uri);
+                        }
+                      }
+                    },
+                    tooltip: '문자',
+                  ),
+                  IconButton(
+                    icon: Icon(
+                      Icons.alternate_email,
+                      color: Theme.of(context).colorScheme.tertiary,
+                    ),
+                    onPressed: () {
+                      // TODO: 이메일 화면 완성 후 구현
+                    },
+                    tooltip: '이메일',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// 연락처 상세 시트
+class ContactDetailSheet extends StatelessWidget {
+  const ContactDetailSheet({
+    super.key,
+    required this.contact,
+    required this.isFavorite,
+    required this.onOrganizationTap,
+    required this.onFavoriteToggle,
+  });
+
+  final Contact contact;
+  final bool isFavorite;
+  final VoidCallback onOrganizationTap;
+  final VoidCallback onFavoriteToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, scrollController) => SingleChildScrollView(
+        controller: scrollController,
+        child: Column(
+          children: [
+            // 핸들
+            Container(
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            // 프로필 헤더
+            Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                children: [
+                  // 아바타 + 상태
+                  Stack(
+                    children: [
+                      CircleAvatar(
+                        radius: 50,
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.primaryContainer,
+                        backgroundImage: contact.avatarUrl != null
+                            ? NetworkImage(contact.avatarUrl!)
+                            : null,
+                        child: contact.avatarUrl == null
+                            ? Text(
+                                (contact.username ?? 'U').substring(0, 1),
+                                style: TextStyle(
+                                  fontSize: 36,
+                                  fontWeight: FontWeight.bold,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onPrimaryContainer,
+                                ),
+                              )
+                            : null,
+                      ),
+                      Positioned(
+                        right: 0,
+                        bottom: 0,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _getStatusColor(contact.status),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            _getStatusText(contact.status),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  // 이름 + 즐겨찾기
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        contact.username ?? '이름 없음',
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton(
+                        icon: Icon(
+                          isFavorite ? Icons.star : Icons.star_border,
+                          color: isFavorite ? Colors.amber : Colors.grey,
+                        ),
+                        onPressed: onFavoriteToggle,
+                      ),
+                    ],
+                  ),
+                  // 조직 (클릭 가능)
+                  TextButton.icon(
+                    onPressed: onOrganizationTap,
+                    icon: const Icon(Icons.corporate_fare, size: 16),
+                    label: Text(
+                      '${contact.department ?? ''} · ${contact.position ?? ''}',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // 빠른 액션 버튼
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _ActionButton(
+                    icon: Icons.phone,
+                    label: '전화',
+                    color: Colors.green,
+                    onTap: () {},
+                  ),
+                  _ActionButton(
+                    icon: Icons.email,
+                    label: '메시지',
+                    color: Colors.blue,
+                    onTap: () {},
+                  ),
+                  _ActionButton(
+                    icon: Icons.alternate_email,
+                    label: '이메일',
+                    color: Colors.orange,
+                    onTap: () {},
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            const Divider(),
+            // 상세 정보
+            if (contact.mobilePhone != null)
+              _DetailTile(
+                icon: Icons.phone_android,
+                label: '휴대폰',
+                value: contact.mobilePhone!,
+              ),
+            if (contact.officePhone != null)
+              _DetailTile(
+                icon: Icons.phone,
+                label: '내선번호',
+                value: contact.officePhone!,
+              ),
+            _DetailTile(icon: Icons.email, label: '이메일', value: contact.email),
+            if (contact.department != null)
+              _DetailTile(
+                icon: Icons.business,
+                label: '소속',
+                value: contact.department!,
+                onTap: onOrganizationTap,
+              ),
+            const SizedBox(height: 40),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          children: [
+            Icon(icon, color: color, size: 28),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: TextStyle(color: color, fontWeight: FontWeight.w500),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailTile extends StatelessWidget {
+  const _DetailTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: Colors.grey),
+      title: Text(
+        label,
+        style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+      ),
+      subtitle: Text(value, style: const TextStyle(fontSize: 16)),
+      trailing: onTap != null ? const Icon(Icons.chevron_right) : null,
+      onTap: onTap,
+    );
+  }
+}
+
+/// 펼치기/접기 가능한 조직 타일
+/// 접힌 상태에서 클릭 → 펼치기
+/// 펼쳐진 상태에서 클릭 → 선택
+class _ExpandableOrgTile extends StatefulWidget {
+  const _ExpandableOrgTile({
+    required this.division,
+    required this.childOrgs,
+    required this.isSelected,
+    required this.initiallyExpanded,
+    required this.contactCount,
+    required this.selectedOrganization,
+    required this.onSelectDivision,
+    required this.onSelectTeam,
+    required this.getContactCount,
+  });
+
+  final Organization division;
+  final List<Organization> childOrgs;
+  final bool isSelected;
+  final bool initiallyExpanded;
+  final int contactCount;
+  final String? selectedOrganization;
+  final VoidCallback onSelectDivision;
+  final void Function(String teamId) onSelectTeam;
+  final int Function(String? orgId) getContactCount;
+
+  @override
+  State<_ExpandableOrgTile> createState() => _ExpandableOrgTileState();
+}
+
+class _ExpandableOrgTileState extends State<_ExpandableOrgTile> {
+  late bool _isExpanded;
+  final ExpansibleController _controller = ExpansibleController();
+
+  @override
+  void initState() {
+    super.initState();
+    _isExpanded = widget.initiallyExpanded;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        controller: _controller,
+        key: ValueKey(widget.division.id),
+        initiallyExpanded: widget.initiallyExpanded,
+        onExpansionChanged: (expanded) {
+          setState(() => _isExpanded = expanded);
+        },
+        leading: GestureDetector(
+          onTap: _handleTap,
+          child: CircleAvatar(
+            backgroundColor: widget.isSelected
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.surfaceContainerHighest,
+            child: Icon(
+              Icons.corporate_fare,
+              color: widget.isSelected ? Colors.white : null,
+              size: 20,
+            ),
+          ),
+        ),
+        title: GestureDetector(
+          onTap: _handleTap,
+          child: Text(
+            '${widget.division.name} (${widget.contactCount})',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: widget.isSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            ),
+          ),
+        ),
+        trailing: widget.isSelected
+            ? Icon(
+                Icons.check_circle,
+                color: Theme.of(context).colorScheme.primary,
+              )
+            : Icon(
+                _isExpanded ? Icons.expand_less : Icons.expand_more,
+                color: Colors.grey,
+              ),
+        children: widget.childOrgs.map((team) {
+          final isTeamSelected = team.id == widget.selectedOrganization;
+          return ListTile(
+            leading: CircleAvatar(
+              backgroundColor: isTeamSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.surfaceContainerHighest,
+              child: Icon(
+                Icons.group,
+                color: isTeamSelected ? Colors.white : null,
+                size: 20,
+              ),
+            ),
+            title: Text(
+              '${team.name} (${widget.getContactCount(team.id)})',
+              style: TextStyle(
+                color: isTeamSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : null,
+              ),
+            ),
+            trailing: isTeamSelected
+                ? Icon(
+                    Icons.check_circle,
+                    color: Theme.of(context).colorScheme.primary,
+                  )
+                : null,
+            contentPadding: const EdgeInsets.only(left: 40, right: 16),
+            onTap: () => widget.onSelectTeam(team.id),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  void _handleTap() {
+    if (_isExpanded) {
+      // 펼쳐진 상태에서 클릭 → 본부 선택
+      widget.onSelectDivision();
+    } else {
+      // 접힌 상태에서 클릭 → 펼치기
+      _controller.expand();
+    }
+  }
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:wise_app/features/auth/auth_repository.dart';
 import 'package:wise_app/features/auth/login_screen.dart';
+import 'package:wise_app/features/contacts/contacts_screen.dart';
 import 'package:wise_app/features/profile/profile_edit_screen.dart';
 import 'package:wise_app/features/profile/profile_screen.dart';
 import 'package:wise_app/home_screen.dart';
@@ -54,6 +55,15 @@ GoRouter router(Ref ref) {
               ),
             ],
           ),
+          // 연락처 탭
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/contacts',
+                builder: (context, state) => const ContactsScreen(),
+              ),
+            ],
+          ),
           // 프로필 탭
           StatefulShellBranch(
             navigatorKey: _shellNavigatorKey,
@@ -100,6 +110,7 @@ class MainScaffold extends StatelessWidget {
         },
         destinations: const [
           NavigationDestination(icon: Icon(Icons.home), label: '홈'),
+          NavigationDestination(icon: Icon(Icons.contacts), label: '연락처'),
           NavigationDestination(icon: Icon(Icons.person), label: '프로필'),
         ],
       ),

--- a/lib/router.g.dart
+++ b/lib/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'cd49da2c1a0a066e86fc00e831861cd1b8451a82';
+String _$routerHash() => r'9255d4b031bdf655003488dc1cef9f736caf4cfa';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1126,7 +1126,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   image_picker: ^1.2.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- 조직도(organizations) 테이블 및 즐겨찾기(favorites) 테이블 생성
- 연락처 카드 개선 (프로필 사진, 내선번호, 즐겨찾기 버튼)
- 연락처 상세 화면 (BottomSheet)
- 검색 기능 강화 (초성 검색, 최근 검색 기록)
- 조직도 펼치기/접기 및 인원수 배지 표시
- 상태 표시 (온라인/오프라인 뱃지)
- 전화/문자 버튼 연동 (url_launcher)

this closes #4 